### PR TITLE
Update about section with scroll

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ function App() {
               </DockIcon>
             </Dock>
           </div>
-          <div className="relative z-10 flex flex-col items-center justify-center min-h-[80vh] w-full text-center">
+          <div className="relative z-10 w-full text-center">
             <Routes>
               <Route path="/" element={
                 <>
@@ -87,9 +87,6 @@ function App() {
                     </Link>
                     <Link to="/projects" aria-label="Go to Projects">
                       <InteractiveHoverButton>Projects</InteractiveHoverButton>
-                    </Link>
-                    <Link to="/about" aria-label="Go to About">
-                      <InteractiveHoverButton>About Me</InteractiveHoverButton>
                     </Link>
                   </div>
                 </>

--- a/src/components/magicui/interactive-hover-button.tsx
+++ b/src/components/magicui/interactive-hover-button.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import { ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-interface InteractiveHoverButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+type InteractiveHoverButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 export const InteractiveHoverButton = React.forwardRef<
   HTMLButtonElement,

--- a/src/components/magicui/rainbow-button.tsx
+++ b/src/components/magicui/rainbow-button.tsx
@@ -3,8 +3,6 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import React from "react";
 
-interface RainbowButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 const rainbowButtonVariants = cva(
   cn(

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -1,18 +1,49 @@
 import { BlurFade } from "@/components/magicui/blur-fade";
 import { WordRotate } from "@/components/magicui/word-rotate";
 import { AuroraText } from "@/components/magicui/aurora-text";
+import { ArrowDown } from "lucide-react";
 
 const Home = () => (
-  <BlurFade>
-    <div className="flex flex-col items-center justify-center min-h-[60vh] w-full text-center">
-        <WordRotate
-          words={["Hola", "Hello", "Bonjour", "Ciao", "Hallo", "Olá", "こんにちは", "안녕하세요", "你好", "Привет"]}
-          className="text-5xl md:text-7xl font-extrabold tracking-tight mb-4 animate-fade-in"
-        />
-        <h2 className="text-2xl md:text-3xl font-semibold mb-2 animate-fade-in [animation-delay:100ms]">I'm <AuroraText>Riki</AuroraText>, a Software Engineer Student</h2>
-        <h3 className="text-lg md:text-xl font-normal text-muted-foreground max-w-xl mb-8 animate-fade-in [animation-delay:200ms]">My passion is to learn everything about technology and programming. I’m always looking for new challenges and opportunities to grow.</h3>
-    </div>
-  </BlurFade>
+  <div className="snap-y snap-mandatory h-screen overflow-y-scroll scroll-smooth">
+    <section className="snap-start h-screen flex flex-col items-center justify-center text-center relative p-4">
+      <WordRotate
+        words={["Hola", "Hello", "Bonjour", "Ciao", "Hallo", "Olá", "こんにちは", "안녕하세요", "你好", "Привет"]}
+        className="text-5xl md:text-7xl font-extrabold tracking-tight mb-4 animate-fade-in"
+      />
+      <h2 className="text-2xl md:text-3xl font-semibold mb-2 animate-fade-in [animation-delay:100ms]">I'm <AuroraText>Riki</AuroraText>, a Software Engineer Student</h2>
+      <h3 className="text-lg md:text-xl font-normal text-muted-foreground max-w-xl mb-8 animate-fade-in [animation-delay:200ms]">My passion is to learn everything about technology and programming. I’m always looking for new challenges and opportunities to grow.</h3>
+      <div className="absolute bottom-10 flex flex-col items-center">
+        <p className="text-sm text-muted-foreground mb-1">Keep scrolling for more information</p>
+        <ArrowDown className="w-6 h-6 animate-bounce" />
+      </div>
+    </section>
+    <section className="snap-start h-screen flex flex-col items-center justify-center p-4">
+      <BlurFade className="text-center">
+        <h2 className="text-3xl md:text-5xl font-bold mb-4">yeah, i'm riki</h2>
+        <p className="text-base md:text-lg text-muted-foreground max-w-xl mb-4">I'm a curious software engineering student who loves creating useful and elegant solutions. Always eager to explore new technologies and share knowledge.</p>
+        <img src="/images/me.jpg" alt="Riki" className="w-40 h-40 rounded-full object-cover" />
+      </BlurFade>
+    </section>
+    <section className="snap-start h-screen flex flex-col items-center justify-center p-4">
+      <BlurFade className="text-center max-w-xl">
+        <h3 className="text-2xl md:text-4xl font-semibold mb-4">Why Software Engineering?</h3>
+        <p className="text-base md:text-lg text-muted-foreground">Technology has always fascinated me, and studying Software Engineering allows me to turn ideas into reality while continuously learning and solving problems.</p>
+      </BlurFade>
+    </section>
+    <section className="snap-start h-screen flex flex-col items-center justify-center p-4">
+      <BlurFade className="text-center max-w-xl">
+        <h3 className="text-2xl md:text-4xl font-semibold mb-4">Hobbies</h3>
+        <p className="text-base md:text-lg text-muted-foreground">I enjoy playing padel, video games, keeping up with tech news and mixing music as a DJ.</p>
+      </BlurFade>
+    </section>
+    <section className="snap-start h-screen flex flex-col items-center justify-center p-4">
+      <BlurFade>
+        <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank" rel="noopener noreferrer" className="text-base md:text-lg text-primary underline">
+          Want to know a secret about me?
+        </a>
+      </BlurFade>
+    </section>
+  </div>
 );
 
 export default Home;


### PR DESCRIPTION
## Summary
- drop About Me button from the home page
- integrate about section into `Home` with scroll-snap sections
- show animated arrow inviting the user to scroll for more info
- fix lint errors in button components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68418ce928248330971c4549fdafdab2