### PR TITLE
Rediseño a SPA: secciones ancladas y nuevos componentes (About, Technologies, Projects, Contact)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,10 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 @media (max-width: 768px) {
   #root {
     padding: 0;
@@ -44,6 +48,22 @@
 
 .read-the-docs {
   color: #888;
+}
+
+.scroll-indicator-text {
+  animation: float 2.8s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.7;
+  }
+  50% {
+    transform: translateY(-6px);
+    opacity: 1;
+  }
 }
 
 /* Responsive fixes for mobile content */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,16 @@
 import './App.css'
 import { Dock, DockIcon } from "@/components/magicui/dock";
-import { Home, Github, Linkedin, Mail } from "lucide-react";
+import { Github, Home, Linkedin, Mail, FolderKanban, Cpu, User } from "lucide-react";
 import { RetroGrid } from "@/components/magicui/retro-grid";
 import { ThemeProvider } from "@/components/theme-provider";
-import { InteractiveHoverButton } from '@/components/magicui/interactive-hover-button';
 import { AnimatedThemeToggler } from "@/components/ui/animated-theme-toggler";
-import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 import { LinkPreview } from "@/components/ui/link-preview";
 import { CVSelection } from "@/components/cv-selection";
 import HomePage from "@/components/pages/Home";
-import Estudios from "@/components/pages/Estudios";
-import Tecnologias from "@/components/pages/Tecnologias";
-import Proyectos from "@/components/pages/Proyectos";
-
+import AboutSection from "@/components/sections/About";
+import TechnologiesSection from "@/components/sections/Technologies";
+import ProjectsSection from "@/components/sections/Projects";
+import ContactSection from "@/components/sections/Contact";
 
 function ModeDockIcon() {
   return (
@@ -23,76 +21,88 @@ function ModeDockIcon() {
 function App() {
   return (
     <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
-      <Router>
-        <div className="relative min-h-screen w-full overflow-x-hidden">
-          <RetroGrid lightLineColor='green' darkLineColor='green' className="fixed inset-0 w-full h-full -z-10" />
-          <div className="relative w-full px-4 md:px-0">
-            {/* Aquí irá el contenido principal del portfolio */}
-          </div>
-          <div className="fixed bottom-0 left-0 w-full flex justify-center z-20 pb-4">
-            <Dock className="shadow-lg">
-              <DockIcon>
-                <Link to="/" aria-label="Inicio">
-                  <Home className="w-7 h-7" />
-                </Link>
-              </DockIcon>
-              <span className="mx-2 h-8 w-px bg-gray-200 dark:bg-gray-700" aria-hidden="true"></span>
-              <DockIcon>
-                <LinkPreview url="https://github.com/RIKICARRE" width={300} height={200}>
-                  <a href="https://github.com/RIKICARRE" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
-                    <Github className="w-7 h-7" />
-                  </a>
-                </LinkPreview>
-              </DockIcon>
-              <DockIcon>
-                <LinkPreview url="https://www.linkedin.com/in/ricardo-carreno-939b78338" width={300} height={200}>
-                  <a href="https://www.linkedin.com/in/ricardo-carreno-939b78338" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
-                    <Linkedin className="w-7 h-7" />
-                  </a>
-                </LinkPreview>
-              </DockIcon>
-              <DockIcon>
-                <a href="mailto:ricardocarremar@icloud.com" aria-label="Email">
-                  <Mail className="w-7 h-7" />
+      <div className="relative min-h-screen w-full overflow-x-hidden">
+        <RetroGrid lightLineColor='green' darkLineColor='green' className="fixed inset-0 w-full h-full -z-10" />
+
+        <main className="relative z-10 flex flex-col gap-24 pb-32 pt-16">
+          <section id="home" className="relative flex min-h-screen items-center justify-center px-4">
+            <HomePage />
+          </section>
+
+          <section id="about" className="scroll-mt-24">
+            <AboutSection />
+          </section>
+
+          <section id="technologies" className="scroll-mt-24">
+            <TechnologiesSection />
+          </section>
+
+          <section id="projects" className="scroll-mt-24">
+            <ProjectsSection />
+          </section>
+
+          <section id="contact" className="scroll-mt-24">
+            <ContactSection />
+          </section>
+        </main>
+
+        <div className="fixed bottom-0 left-0 w-full flex justify-center z-20 pb-4">
+          <Dock className="shadow-lg">
+            <DockIcon>
+              <a href="#home" aria-label="Inicio">
+                <Home className="w-7 h-7" />
+              </a>
+            </DockIcon>
+            <DockIcon>
+              <a href="#about" aria-label="Sobre mí">
+                <User className="w-7 h-7" />
+              </a>
+            </DockIcon>
+            <DockIcon>
+              <a href="#technologies" aria-label="Tecnologías">
+                <Cpu className="w-7 h-7" />
+              </a>
+            </DockIcon>
+            <DockIcon>
+              <a href="#projects" aria-label="Proyectos">
+                <FolderKanban className="w-7 h-7" />
+              </a>
+            </DockIcon>
+            <DockIcon>
+              <a href="#contact" aria-label="Contacto">
+                <Mail className="w-7 h-7" />
+              </a>
+            </DockIcon>
+            <span className="mx-2 h-8 w-px bg-gray-200 dark:bg-gray-700" aria-hidden="true"></span>
+            <DockIcon>
+              <LinkPreview url="https://github.com/RIKICARRE" width={300} height={200}>
+                <a href="https://github.com/RIKICARRE" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                  <Github className="w-7 h-7" />
                 </a>
-              </DockIcon>
-              <DockIcon>
-                <CVSelection />
-              </DockIcon>
-              <span className="mx-2 h-8 w-px bg-gray-200 dark:bg-gray-700" aria-hidden="true"></span>
-              <DockIcon>
-                <ModeDockIcon />
-              </DockIcon>
-            </Dock>
-          </div>
-          <div className="relative z-10 flex flex-col items-center justify-center min-h-[80vh] w-full text-center">
-            <Routes>
-              <Route path="/" element={
-                <>
-                  <HomePage />
-                  <div className="flex flex-col md:flex-row gap-4 mb-12 animate-fade-in [animation-delay:300ms]">
-                    <Link to="/studies" aria-label="Go to Studies">
-                      <InteractiveHoverButton>Studies</InteractiveHoverButton>
-                    </Link>
-                    <Link to="/technologies" aria-label="Go to Technologies">
-                      <InteractiveHoverButton>Technologies</InteractiveHoverButton>
-                    </Link>
-                    <Link to="/projects" aria-label="Go to Projects" className="relative">
-                      <InteractiveHoverButton>Projects</InteractiveHoverButton>
-                      <span className="absolute -top-2 -right-2 bg-red-500 text-white text-[10px] font-bold px-2 py-1 rounded-full animate-pulse z-50">
-                        NEW
-                      </span>
-                    </Link>
-                  </div>
-                </>
-              } />
-              <Route path="/studies" element={<Estudios />} />
-              <Route path="/technologies" element={<Tecnologias />} />
-              <Route path="/projects" element={<Proyectos />} />
-            </Routes>
-          </div>
+              </LinkPreview>
+            </DockIcon>
+            <DockIcon>
+              <LinkPreview url="https://www.linkedin.com/in/ricardo-carreno-939b78338" width={300} height={200}>
+                <a
+                  href="https://www.linkedin.com/in/ricardo-carreno-939b78338"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="LinkedIn"
+                >
+                  <Linkedin className="w-7 h-7" />
+                </a>
+              </LinkPreview>
+            </DockIcon>
+            <DockIcon>
+              <CVSelection />
+            </DockIcon>
+            <span className="mx-2 h-8 w-px bg-gray-200 dark:bg-gray-700" aria-hidden="true"></span>
+            <DockIcon>
+              <ModeDockIcon />
+            </DockIcon>
+          </Dock>
         </div>
-      </Router>
+      </div>
     </ThemeProvider>
   )
 }

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -1,18 +1,29 @@
 import { BlurFade } from "@/components/magicui/blur-fade";
 import { WordRotate } from "@/components/magicui/word-rotate";
 import { AuroraText } from "@/components/magicui/aurora-text";
+import { ChevronDown } from "lucide-react";
 
 const Home = () => (
   <BlurFade>
-    <div className="flex flex-col items-center justify-center min-h-[60vh] w-full text-center px-4 md:px-0">
+    <div className="relative flex flex-col items-center justify-center min-h-[70vh] w-full text-center px-4 md:px-0">
       <WordRotate
         words={["Hola", "Hello", "Bonjour", "Ciao", "Hallo", "Olá", "こんにちは", "안녕하세요", "你好", "Привет"]}
         className="text-4xl md:text-7xl font-extrabold tracking-tight mb-4 animate-fade-in"
       />
-      <h2 className="text-xl md:text-3xl font-semibold mb-2 animate-fade-in [animation-delay:100ms]">I'm <AuroraText>Riki</AuroraText>, a Software Engineering Graduate</h2>
+      <h2 className="text-xl md:text-3xl font-semibold mb-2 animate-fade-in [animation-delay:100ms]">
+        Soy <AuroraText>Ricardo</AuroraText>, graduado en Ingeniería del Software
+      </h2>
       <h3 className="text-base md:text-xl font-normal text-muted-foreground max-w-xl mb-8 animate-fade-in [animation-delay:200ms]">
-        Full-stack developer specializing in Java, Spring Boot, and React. Passionate about building secure, user-centric applications and currently advancing in cybersecurity.
+        Full-stack developer con foco en Java, Spring Boot y React. Me apasiona construir aplicaciones seguras,
+        centradas en el usuario y con arquitecturas escalables.
       </h3>
+      <div className="absolute bottom-6 left-1/2 flex -translate-x-1/2 flex-col items-center gap-2 text-xs text-muted-foreground">
+        <span className="scroll-indicator-text">Sigue bajando para conocer más</span>
+        <div className="flex flex-col items-center">
+          <ChevronDown className="h-5 w-5 animate-bounce" />
+          <ChevronDown className="-mt-2 h-5 w-5 animate-bounce [animation-delay:150ms]" />
+        </div>
+      </div>
     </div>
   </BlurFade>
 );

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -1,0 +1,208 @@
+import { BlurFade } from "@/components/magicui/blur-fade";
+import { BoxReveal } from "@/components/magicui/box-reveal";
+import { ShineBorder } from "@/components/magicui/shine-border";
+import { motion } from "framer-motion";
+import { Award, BadgeCheck, GraduationCap, Sparkles } from "lucide-react";
+
+const educationTimeline = [
+  {
+    period: "2021 — 2025",
+    title: "Grado en Ingeniería del Software",
+    institution: "Universidad de Sevilla",
+    status: "Finalizado",
+    milestones: ["Arquitecturas modernas", "Ciberseguridad", "Desarrollo full-stack"],
+    description:
+      "Formación centrada en diseño de software, metodologías ágiles y construcción de soluciones escalables con foco en calidad.",
+  },
+  {
+    period: "2020 — 2021",
+    title: "Certificación de Inglés B2",
+    institution: "Cambridge English",
+    status: "Finalizado",
+    milestones: ["Comunicación profesional", "Presentaciones", "Documentación técnica"],
+    description:
+      "Refuerzo de habilidades lingüísticas orientadas a contextos profesionales y técnicos.",
+  },
+  {
+    period: "2019 — 2020",
+    title: "Bachillerato en Ciencias",
+    institution: "Colegio Marista Nuestra Señora del Carmen",
+    status: "Finalizado",
+    milestones: ["Pensamiento analítico", "Bases científicas", "Trabajo colaborativo"],
+    description:
+      "Especialización en ciencias con enfoque en pensamiento crítico y resolución de problemas.",
+  },
+];
+
+const courses = [
+  {
+    title: "Especialización en Ciberseguridad",
+    provider: "Plataforma online",
+    status: "En curso",
+    certified: false,
+    description: "Actualización continua sobre detección de vulnerabilidades, OWASP y hardening.",
+  },
+  {
+    title: "Docker & DevOps Fundamentals",
+    provider: "Academia técnica",
+    status: "Completado",
+    certified: true,
+    description: "Buenas prácticas de despliegue, orquestación y automatización.",
+  },
+  {
+    title: "Arquitecturas Backend con Java",
+    provider: "Bootcamp intensivo",
+    status: "Completado",
+    certified: true,
+    description: "Diseño de APIs, pruebas automatizadas y seguridad en servicios.",
+  },
+];
+
+const AboutSection = () => (
+  <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-10">
+    <BlurFade>
+      <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+        <div className="space-y-6">
+          <BoxReveal boxColor="#7C3AED">
+            <h2 className="text-3xl md:text-4xl font-bold tracking-tight">Sobre mí</h2>
+          </BoxReveal>
+          <p className="text-base md:text-lg text-muted-foreground">
+            Soy <span className="font-semibold text-foreground">Ricardo Carreño</span>, graduado en Ingeniería del
+            Software. Me enfoco en construir productos digitales seguros, usables y con arquitectura sólida, combinando
+            desarrollo full-stack con una visión clara de negocio y seguridad.
+          </p>
+          <div className="space-y-3 text-sm md:text-base text-muted-foreground">
+            <p>
+              Mi objetivo es diseñar experiencias digitales que sean elegantes para el usuario y resistentes para el
+              negocio, con especial interés en ciberseguridad y automatización.
+            </p>
+            <p>
+              Actualmente sigo ampliando mi formación en seguridad, cloud y patrones de arquitectura modernos.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {["Full-stack", "Arquitectura", "Ciberseguridad", "Automatización"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium text-foreground/80"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div className="relative">
+          <div className="absolute -inset-4 rounded-[32px] bg-gradient-to-br from-violet-500/20 via-fuchsia-500/10 to-emerald-500/20 blur-2xl" />
+          <div className="relative overflow-hidden rounded-[28px] border border-border/60 bg-card/70 p-4 shadow-xl backdrop-blur">
+            <div className="aspect-square w-full overflow-hidden rounded-2xl border border-dashed border-border/60 bg-muted/40">
+              <img
+                src="/images/ricardo.jpg"
+                alt="Ricardo Carreño"
+                className="h-full w-full object-cover"
+              />
+            </div>
+            <p className="mt-4 text-xs text-muted-foreground">
+              Sustituye <span className="font-semibold text-foreground">/public/images/ricardo.jpg</span> por tu foto
+              personal.
+            </p>
+          </div>
+        </div>
+      </div>
+    </BlurFade>
+
+    <BlurFade>
+      <section className="relative overflow-hidden rounded-[28px] border border-border/60 bg-card/70 p-8 shadow-xl">
+        <ShineBorder shineColor={["#7C3AED", "#EC4899", "#22C55E"]} borderWidth={2} />
+        <div className="mb-10 flex items-center gap-3">
+          <GraduationCap className="h-6 w-6 text-primary" />
+          <h3 className="text-2xl font-semibold">Cronología de formación</h3>
+        </div>
+        <div className="relative">
+          <div className="absolute left-4 top-0 h-full w-px bg-gradient-to-b from-primary/50 via-border to-transparent" />
+          <div className="space-y-8">
+            {educationTimeline.map((item, index) => (
+              <motion.article
+                key={item.title}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.4, delay: index * 0.1 }}
+                viewport={{ once: true }}
+                className="relative pl-12"
+              >
+                <span className="absolute left-[9px] top-5 flex h-3 w-3 items-center justify-center rounded-full bg-primary shadow-[0_0_0_6px_rgba(124,58,237,0.2)]" />
+                <div className="rounded-2xl border border-border/60 bg-background/70 p-6 shadow-sm">
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span className="rounded-full border border-border/60 px-2 py-0.5">{item.period}</span>
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-primary">{item.status}</span>
+                  </div>
+                  <h4 className="mt-3 text-lg font-semibold text-foreground">{item.title}</h4>
+                  <p className="text-sm text-muted-foreground">{item.institution}</p>
+                  <p className="mt-3 text-sm text-muted-foreground">{item.description}</p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {item.milestones.map((milestone) => (
+                      <span
+                        key={milestone}
+                        className="rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground"
+                      >
+                        {milestone}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </motion.article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </BlurFade>
+
+    <BlurFade>
+      <section className="relative overflow-hidden rounded-[28px] border border-border/60 bg-card/70 p-8 shadow-xl">
+        <ShineBorder shineColor={["#22C55E", "#14B8A6", "#3B82F6"]} borderWidth={2} />
+        <div className="mb-8 flex items-center gap-3">
+          <Sparkles className="h-6 w-6 text-primary" />
+          <h3 className="text-2xl font-semibold">Cursos y formación continua</h3>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2">
+          {courses.map((course, index) => (
+            <motion.div
+              key={course.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4, delay: index * 0.1 }}
+              viewport={{ once: true }}
+              className="group relative overflow-hidden rounded-2xl border border-border/60 bg-background/70 p-6 shadow-sm"
+            >
+              <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+                <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-emerald-500/10" />
+              </div>
+              <div className="relative flex items-start justify-between gap-4">
+                <div>
+                  <h4 className="text-lg font-semibold text-foreground">{course.title}</h4>
+                  <p className="text-sm text-muted-foreground">{course.provider}</p>
+                </div>
+                {course.certified ? (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-1 text-xs font-medium text-emerald-500">
+                    <BadgeCheck className="h-3.5 w-3.5" />
+                    Certificado
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-1 text-xs font-medium text-amber-500">
+                    <Award className="h-3.5 w-3.5" />
+                    Formativo
+                  </span>
+                )}
+              </div>
+              <p className="relative mt-4 text-sm text-muted-foreground">{course.description}</p>
+              <span className="relative mt-4 inline-flex rounded-full border border-border/60 px-3 py-1 text-xs text-muted-foreground">
+                {course.status}
+              </span>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+    </BlurFade>
+  </div>
+);
+
+export default AboutSection;

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,0 +1,74 @@
+import { BlurFade } from "@/components/magicui/blur-fade";
+import { ShineBorder } from "@/components/magicui/shine-border";
+import { motion } from "framer-motion";
+import { Github, Linkedin, Mail } from "lucide-react";
+
+const contacts = [
+  {
+    title: "Email corporativo",
+    description: "Contacto directo para oportunidades profesionales.",
+    value: "ricardocarremar@icloud.com",
+    href: "mailto:ricardocarremar@icloud.com",
+    icon: Mail,
+  },
+  {
+    title: "LinkedIn",
+    description: "Actividad profesional, certificaciones y networking.",
+    value: "linkedin.com/in/ricardo-carreno-939b78338",
+    href: "https://www.linkedin.com/in/ricardo-carreno-939b78338",
+    icon: Linkedin,
+  },
+  {
+    title: "GitHub",
+    description: "Repositorios, contribuciones y proyectos activos.",
+    value: "github.com/RIKICARRE",
+    href: "https://github.com/RIKICARRE",
+    icon: Github,
+  },
+];
+
+const ContactSection = () => (
+  <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-4 py-12">
+    <BlurFade>
+      <div className="text-center">
+        <h2 className="text-3xl md:text-5xl font-extrabold tracking-tight">Contacto</h2>
+        <p className="mx-auto mt-3 max-w-2xl text-sm md:text-base text-muted-foreground">
+          ¿Hablamos? Estas son mis vías principales para colaborar, compartir propuestas o explorar oportunidades.
+        </p>
+      </div>
+    </BlurFade>
+
+    <div className="grid gap-6 md:grid-cols-3">
+      {contacts.map((contact, index) => (
+        <motion.a
+          key={contact.title}
+          href={contact.href}
+          target={contact.href.startsWith("mailto") ? undefined : "_blank"}
+          rel={contact.href.startsWith("mailto") ? undefined : "noopener noreferrer"}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: index * 0.1 }}
+          viewport={{ once: true }}
+          className="group relative overflow-hidden rounded-3xl border border-border/60 bg-card/70 p-6 shadow-xl transition-transform duration-300 hover:-translate-y-1"
+        >
+          <ShineBorder shineColor={["#22C55E", "#3B82F6", "#EC4899"]} borderWidth={1} />
+          <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-emerald-500/10" />
+          </div>
+          <div className="relative flex flex-col gap-4">
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <contact.icon className="h-6 w-6" />
+            </span>
+            <div>
+              <h3 className="text-lg font-semibold text-foreground">{contact.title}</h3>
+              <p className="mt-1 text-sm text-muted-foreground">{contact.description}</p>
+            </div>
+            <span className="text-sm font-medium text-foreground/80">{contact.value}</span>
+          </div>
+        </motion.a>
+      ))}
+    </div>
+  </div>
+);
+
+export default ContactSection;

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -1,0 +1,177 @@
+import { BlurFade } from "@/components/magicui/blur-fade";
+import { RainbowButton } from "@/components/magicui/rainbow-button";
+import { ShineBorder } from "@/components/magicui/shine-border";
+import { CardContainer, CardItem } from "@/components/ui/3d-card";
+import { motion } from "framer-motion";
+import { ArrowUpRight, FolderKanban, Sparkles } from "lucide-react";
+
+type ProjectLink = {
+  label: string;
+  url: string;
+};
+
+type Project = {
+  title: string;
+  category: string;
+  summary: string;
+  description: string;
+  highlights: string[];
+  stack: string[];
+  image: string;
+  links: ProjectLink[];
+};
+
+const projects: Project[] = [
+  {
+    title: "Municipal Sports Management",
+    category: "Full-Stack",
+    summary: "Sistema para reservas deportivas en municipios pequeños.",
+    description:
+      "Proyecto final de grado enfocado en centralizar reservas, gestionar aforos y digitalizar procesos locales con una UI clara y accesible.",
+    highlights: ["Arquitectura monolítica", "Flujos de reserva", "Panel administrativo"],
+    stack: ["Python", "Django", "SQLite", "HTML"],
+    image: "/images/inicio_rede.jpeg",
+    links: [
+      { label: "Repositorio", url: "https://github.com/RIKICARRE/ReDe_TFG" },
+      {
+        label: "Publicación",
+        url: "https://www.linkedin.com/posts/ricardo-carreno-939b78338_tfg-ricardo-carre%C3%B1o-mari%C3%B1o-rede-activity-7405162023409385472-htR4?utm_source=share&utm_medium=member_desktop&rcm=ACoAAFTj9j0BdtL40ztZ-kLvrFl6ZSwcvm1NbhE",
+      },
+    ],
+  },
+  {
+    title: "MapYourWorld",
+    category: "Full-Stack",
+    summary: "App gamificada para explorar el mundo por distritos.",
+    description:
+      "Aplicación geolocalizada con desafíos y recompensas, que integra mapas colaborativos y progreso en tiempo real.",
+    highlights: ["Mapas interactivos", "Gamificación", "Modelo freemium"],
+    stack: ["React", "Spring Boot", "PostgreSQL", "Mapbox"],
+    image: "/images/logo_myw.png",
+    links: [
+      { label: "Repositorio", url: "https://github.com/ISPP-Grupo-7/MapYourWorld" },
+      { label: "Landing", url: "https://mapyourworld.netlify.app/" },
+    ],
+  },
+  {
+    title: "Portfolio Experience",
+    category: "Frontend",
+    summary: "Portafolio interactivo con motion y diseño responsive.",
+    description:
+      "Experiencia digital pensada para presentar proyectos con animaciones, dark mode y componentes visuales de alto impacto.",
+    highlights: ["Motion design", "Componentes reutilizables", "Tema dinámico"],
+    stack: ["React", "Vite", "Tailwind", "Framer Motion"],
+    image: "/images/portfolio.png",
+    links: [{ label: "Repositorio", url: "https://github.com/RIKICARRE/portfolio_v2" }],
+  },
+  {
+    title: "Remote Sensing",
+    category: "Data Science",
+    summary: "Análisis de imágenes satelitales para cambios ambientales.",
+    description:
+      "Procesamiento de datos multiespectrales con NDVI y clasificación de cobertura para evaluar impacto en el entorno.",
+    highlights: ["NDVI", "Corrección atmosférica", "Clasificación"],
+    stack: ["Python", "MATLAB", "Remote Sensing"],
+    image: "/images/t.png",
+    links: [{ label: "Repositorio", url: "https://github.com/RIKICARRE/Teledeteccion" }],
+  },
+];
+
+const ProjectsSection = () => (
+  <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-10">
+    <BlurFade>
+      <div className="text-center">
+        <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-border/60 px-4 py-2 text-xs text-muted-foreground">
+          <Sparkles className="h-4 w-4 text-primary" />
+          Proyectos destacados y en evolución
+        </div>
+        <h2 className="text-3xl md:text-5xl font-extrabold tracking-tight">Proyectos</h2>
+        <p className="mx-auto mt-3 max-w-2xl text-sm md:text-base text-muted-foreground">
+          Cada proyecto representa una pieza de mi recorrido profesional. Aquí muestro la esencia técnica y los detalles
+          clave para entender el impacto de cada solución.
+        </p>
+      </div>
+    </BlurFade>
+
+    <div className="grid gap-8 lg:grid-cols-2">
+      {projects.map((project, index) => (
+        <motion.div
+          key={project.title}
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: index * 0.1 }}
+          viewport={{ once: true }}
+        >
+          <CardContainer>
+            <div className="group relative h-full overflow-hidden rounded-[28px] border border-border/60 bg-card/70 p-6 shadow-xl">
+              <ShineBorder shineColor={["#A07CFE", "#FE8FB5", "#FFBE7B"]} borderWidth={1} />
+              <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+                <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-emerald-500/10" />
+              </div>
+              <div className="relative space-y-5">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span className="inline-flex items-center gap-2">
+                    <FolderKanban className="h-4 w-4 text-primary" />
+                    {project.category}
+                  </span>
+                </div>
+                <div className="flex items-center gap-4">
+                  <CardItem translateZ={30} className="w-20">
+                    <img
+                      src={project.image}
+                      alt={project.title}
+                      className="h-20 w-20 rounded-2xl object-cover"
+                    />
+                  </CardItem>
+                  <div>
+                    <h3 className="text-xl font-semibold text-foreground">{project.title}</h3>
+                    <p className="text-sm text-muted-foreground">{project.summary}</p>
+                  </div>
+                </div>
+                <p className="text-sm text-muted-foreground">{project.description}</p>
+
+                <div className="flex flex-wrap gap-2">
+                  {project.stack.map((item) => (
+                    <span
+                      key={item}
+                      className="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-foreground/80"
+                    >
+                      {item}
+                    </span>
+                  ))}
+                </div>
+
+                <details className="rounded-2xl border border-border/60 bg-background/70 p-4">
+                  <summary className="cursor-pointer list-none text-sm font-medium text-foreground">
+                    Detalles del proyecto
+                  </summary>
+                  <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                    {project.highlights.map((highlight) => (
+                      <li key={highlight} className="flex items-start gap-2">
+                        <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" />
+                        {highlight}
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+
+                <div className="flex flex-wrap gap-3">
+                  {project.links.map((link) => (
+                    <a key={link.url} href={link.url} target="_blank" rel="noopener noreferrer">
+                      <RainbowButton>
+                        {link.label}
+                        <ArrowUpRight className="ml-2 h-4 w-4" />
+                      </RainbowButton>
+                    </a>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </CardContainer>
+        </motion.div>
+      ))}
+    </div>
+  </div>
+);
+
+export default ProjectsSection;

--- a/src/components/sections/Technologies.tsx
+++ b/src/components/sections/Technologies.tsx
@@ -1,0 +1,140 @@
+import { BlurFade } from "@/components/magicui/blur-fade";
+import { ShineBorder } from "@/components/magicui/shine-border";
+import { VelocityScroll } from "@/components/magicui/scroll-based-velocity";
+import { LogoCarousel } from "@/components/ui/logo-carousel";
+import { motion } from "framer-motion";
+import { Atom, Cpu, ShieldCheck, Wand2 } from "lucide-react";
+
+const domains = [
+  {
+    title: "Frontend experiencial",
+    description: "Interfaces rápidas, responsivas y con motion design pensado para convertir.",
+    icon: Wand2,
+    stack: ["React", "TypeScript", "Tailwind", "Framer Motion"],
+  },
+  {
+    title: "Backend sólido",
+    description: "APIs seguras, arquitectura limpia y foco en escalabilidad.",
+    icon: Cpu,
+    stack: ["Java", "Spring Boot", "Python", "SQL"],
+  },
+  {
+    title: "Ciberseguridad aplicada",
+    description: "Buenas prácticas OWASP, cifrado y análisis de riesgos integrados.",
+    icon: ShieldCheck,
+    stack: ["OWASP", "Cryptography", "Hardening", "Auditoría"],
+  },
+  {
+    title: "Automatización & DevOps",
+    description: "Pipelines, contenedores y entregas continuas para acelerar equipos.",
+    icon: Atom,
+    stack: ["Docker", "GitHub", "Azure", "Bash"],
+  },
+];
+
+const techCloud = [
+  "React",
+  "Vite",
+  "TypeScript",
+  "JavaScript",
+  "Tailwind CSS",
+  "HTML5",
+  "CSS3",
+  "Python",
+  "Django",
+  "Flask",
+  "Java",
+  "Spring Boot",
+  "SQL",
+  "MySQL",
+  "Docker",
+  "Azure",
+  "Selenium",
+  "SonarQube",
+  "MATLAB",
+  "Criptografía",
+];
+
+const TechnologiesSection = () => (
+  <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 py-10">
+    <BlurFade>
+      <div className="text-center">
+        <VelocityScroll
+          numRows={1}
+          defaultVelocity={3}
+          className="text-3xl md:text-5xl font-extrabold tracking-tight mb-4"
+        >
+          Tecnologías & Herramientas
+        </VelocityScroll>
+        <p className="mx-auto max-w-2xl text-sm md:text-base text-muted-foreground">
+          Trabajo con un stack moderno y versátil, combinando front-end avanzado, back-end robusto y prácticas de
+          seguridad para entregar productos confiables.
+        </p>
+      </div>
+    </BlurFade>
+
+    <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+      <div className="grid gap-6 md:grid-cols-2">
+        {domains.map((domain, index) => (
+          <motion.article
+            key={domain.title}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, delay: index * 0.1 }}
+            viewport={{ once: true }}
+            className="group relative overflow-hidden rounded-2xl border border-border/60 bg-card/70 p-6 shadow-lg"
+          >
+            <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/15 via-transparent to-emerald-500/10" />
+            </div>
+            <div className="relative space-y-4">
+              <domain.icon className="h-6 w-6 text-primary" />
+              <div>
+                <h3 className="text-lg font-semibold text-foreground">{domain.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{domain.description}</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {domain.stack.map((item) => (
+                  <span
+                    key={item}
+                    className="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-foreground/80"
+                  >
+                    {item}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </motion.article>
+        ))}
+      </div>
+
+      <BlurFade>
+        <section className="relative overflow-hidden rounded-3xl border border-border/60 bg-card/70 p-6 shadow-xl">
+          <ShineBorder shineColor={["#A07CFE", "#FE8FB5", "#FFBE7B"]} borderWidth={2} />
+          <div className="mb-6 flex items-center gap-3">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <Cpu className="h-5 w-5" />
+            </span>
+            <div>
+              <h3 className="text-lg font-semibold">Stack en movimiento</h3>
+              <p className="text-xs text-muted-foreground">Carrusel dinámico de tecnologías clave</p>
+            </div>
+          </div>
+          <LogoCarousel columns={3} />
+          <div className="mt-6 flex flex-wrap gap-2">
+            {techCloud.map((tech) => (
+              <span
+                key={tech}
+                className="rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground"
+              >
+                {tech}
+              </span>
+            ))}
+          </div>
+        </section>
+      </BlurFade>
+    </div>
+  </div>
+);
+
+export default TechnologiesSection;


### PR DESCRIPTION
### Motivation
- Unificar el portfolio en una sola página (SPA) con recorrido por scroll para una experiencia continua y más visual. 
- Sustituir la navegación basada en rutas por anclas y un dock fijo que facilite el acceso a cada sección en cualquier dispositivo. 
- Crear secciones más expresivas y animadas para `About`, `Technologies`, `Projects` y `Contact` con estructura modular y capacidad de evolución. 

### Description
- Reemplacé el layout con router por un flujo de una sola página en `src/App.tsx` y añadí anclas (`#home`, `#about`, `#technologies`, `#projects`, `#contact`) en el dock de navegación. 
- Añadí nuevas secciones como componentes reutilizables: `src/components/sections/About.tsx`, `src/components/sections/Technologies.tsx`, `src/components/sections/Projects.tsx` y `src/components/sections/Contact.tsx`. 
- Actualicé el hero en `src/components/pages/Home.tsx` para incluir indicador visual de scroll y añadí comportamiento de scroll suave y animación en `src/App.css`. 
- Aproveché componentes existentes (`BlurFade`, `ShineBorder`, `LogoCarousel`, `3d-card`, etc.) y añadí layouts animados con `framer-motion`, manteniendo la estructura modular y accesible; los cambios se aplicaron en la rama `spa-redesign`. 

### Testing
- Levanté el servidor de desarrollo con `npm run dev` usando Vite, el servidor respondió correctamente (Vite ready, URLs locales y de red) y no hubo errores de arranque. 
- Generé una captura visual comprobatoria ejecutando un script de Playwright que tomó `artifacts/portfolio-spa.png`, y la captura se generó correctamente. 
- No se ejecutaron tests unitarios ni de integración automatizados en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9350cd0c8330ad99ab2db54c7ed0)